### PR TITLE
chore: set linux-loader source to be the git repository, since version 0.4.0 was yanked from crates.io

### DIFF
--- a/vmm/Cargo.lock
+++ b/vmm/Cargo.lock
@@ -181,8 +181,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 [[package]]
 name = "linux-loader"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
+source = "git+https://github.com/rust-vmm/linux-loader?rev=v0.4.0#9539d6dd21fe92f21f7cd25df65bf0911af80815"
 dependencies = [
  "vm-memory",
 ]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bin/test.rs"
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.11.0"
 libc = "0.2.91"
-linux-loader = { version = "0.4.0", features = ["bzimage", "elf"] }
+linux-loader = { git = "https://github.com/rust-vmm/linux-loader", rev = "v0.4.0", features = ["bzimage", "elf"] }
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.15.0"
 


### PR DESCRIPTION
0.4.0 was yanked from crates.Io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency source configuration for linux-loader. No functional changes or user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->