### PR TITLE
feat(vmm): shutdown guest properly

### DIFF
--- a/vmm/src/kernel.rs
+++ b/vmm/src/kernel.rs
@@ -50,7 +50,7 @@ const CMDLINE_START: u64 = 0x0002_0000;
 /// Maximum size for kernel command line
 const CMDLINE_MAX_SIZE: usize = 4096;
 // Default command line
-const CMDLINE: &str = "console=ttyS0 i8042.nokbd reboot=k panic=1 pci=off";
+const CMDLINE: &str = "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off";
 
 fn add_e820_entry(
     params: &mut boot_params,
@@ -152,7 +152,7 @@ pub fn kernel_setup(
 
         // Add rdinit to command line
         cmdline
-            .insert_str(" rdinit=/init")
+            .insert_str(" rdinit=/bin/sh")
             .map_err(Error::Cmdline)?;
 
         println!(


### PR DESCRIPTION
Refers to #12
Fix to shutdown guest using reboot -f. 
This code is stopping all started vcpu and handle the reboot command with reboot=t 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VM now gracefully shuts down with coordinated thread termination instead of forceful process exit.
  * Signal-based interruption mechanism for improved vCPU thread control.

* **Refactor**
  * vCPU execution redesigned with multithreaded architecture and enhanced thread lifecycle management.
  * Kernel boot parameters updated for improved system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->