### PR TITLE
fix: create nat table with the right name

### DIFF
--- a/backend/virt/src/bin/run_vm.rs
+++ b/backend/virt/src/bin/run_vm.rs
@@ -102,8 +102,7 @@ async fn main() {
                 return eprintln!("Error: Guest IP and Host IP are not in the same subnet");
             }
 
-            // Noa: this line is crashing, this is the problem
-            // virt::network::setup_nat(guest_ip, prefix).expect("Failed to set up NAT");
+            virt::network::setup_nat(guest_ip, prefix).expect("Failed to set up NAT");
 
             virt::network::setup_guest_iface(&tap_name, "cloudebrtest")
                 .await

--- a/backend/virt/src/network.rs
+++ b/backend/virt/src/network.rs
@@ -162,18 +162,21 @@ pub fn setup_nat(ip_range: Ipv4Addr, ip_mask: u8) -> Result<(), Box<dyn std::err
     debug!("Setting up NAT rules");
     let mut batch = Batch::new();
 
+    const TABLE: &str = "cloude_nat";
+    const CHAIN: &str = "cloude_postr";
+
     // Create nat table
     batch.add(schema::NfListObject::Table(schema::Table {
         family: types::NfFamily::IP,
-        name: "nat".into(),
+        name: TABLE.into(),
         ..Default::default()
     }));
 
     // Create postrouting chain in nat table
     batch.add(schema::NfListObject::Chain(schema::Chain {
         family: types::NfFamily::IP,
-        table: "cloude_nat".into(),
-        name: "cloude_postr".into(),
+        table: TABLE.into(),
+        name: CHAIN.into(),
         _type: Some(types::NfChainType::NAT),
         hook: Some(types::NfHook::Postrouting),
         prio: Some(1),
@@ -184,8 +187,8 @@ pub fn setup_nat(ip_range: Ipv4Addr, ip_mask: u8) -> Result<(), Box<dyn std::err
     // Add masquerade rule to postrouting chain (only for bridge network traffic)
     batch.add(schema::NfListObject::Rule(schema::Rule {
         family: types::NfFamily::IP,
-        table: "cloude_nat".into(),
-        chain: "cloude_postr".into(),
+        table: TABLE.into(),
+        chain: CHAIN.into(),
         expr: vec![
             Statement::Match(Match {
                 left: Expression::Named(NamedExpression::Payload(Payload::PayloadField(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VM network address translation (NAT) is now properly enabled during VM startup, improving network connectivity for virtual machines on the same subnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->