### PR TITLE
feat: fixed NAT setup to use dynamic subnet and IPv4 forwarding

### DIFF
--- a/backend/virt/src/bin/run_vm.rs
+++ b/backend/virt/src/bin/run_vm.rs
@@ -17,16 +17,6 @@ fn same_subnet(ip1: Ipv4Addr, ip2: Ipv4Addr, prefix_len: u8) -> bool {
     (u32::from(ip1) & mask) == (u32::from(ip2) & mask)
 }
 
-/// Return network base address from an IP and prefix length.
-fn network_addr(ip: Ipv4Addr, prefix_len: u8) -> Ipv4Addr {
-    let mask = if prefix_len == 0 {
-        0
-    } else {
-        u32::MAX << (32 - u32::from(prefix_len))
-    };
-    (u32::from(ip) & mask).into()
-}
-
 fn get_env_ip(var_name: &str) -> Result<Option<Ipv4Addr>, std::io::Error> {
     match env::var(var_name) {
         Ok(val) => val.parse().map(Some).map_err(|e| {
@@ -112,7 +102,7 @@ async fn main() {
                 return eprintln!("Error: Guest IP and Host IP are not in the same subnet");
             }
 
-            let network = network_addr(guest_ip, prefix);
+            let network = virt::network::network_addr(guest_ip, prefix);
             virt::network::setup_nat(network, prefix).expect("Failed to set up NAT");
 
             virt::network::setup_guest_iface(&tap_name, "cloudebrtest")

--- a/backend/virt/src/network.rs
+++ b/backend/virt/src/network.rs
@@ -111,7 +111,7 @@ async fn create_bridge(handle: &Handle, name: &str) -> Result<u32, rtnetlink::Er
 }
 
 /// Compute network address for an IPv4 CIDR.
-fn network_addr(ip: Ipv4Addr, prefix_len: u8) -> Result<Ipv4Addr, Box<dyn std::error::Error>> {
+pub fn network_addr(ip: Ipv4Addr, prefix_len: u8) -> Result<Ipv4Addr, Box<dyn std::error::Error>> {
     if prefix_len > 32 {
         return Err(format!("invalid IPv4 prefix length: {}", prefix_len).into());
     }


### PR DESCRIPTION
The NAT should work now :)

- Compute subnet base address from guest IP and prefix length
- Ensure host IPv4 forwarding is enabled during NAT setup
- Fix rule detection to match actual nftables table/chain names
- Make table, chain, and rule creation conditional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * More robust VM networking setup: improved NAT handling that detects and reuses existing components, enables IPv4 forwarding when needed, and applies incremental updates instead of full rule rebuilds.
  * Improved logging and faster, more reliable VM network initialization when partial network state already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->