### PR TITLE
feat: Connect backend with CLI

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -66,8 +66,7 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    let server_addr =
-        env::var("AGENT_SERVER_ADDR").unwrap_or_else(|_| "0.0.0.0:3001".to_string());
+    let server_addr = env::var("AGENT_SERVER_ADDR").unwrap_or_else(|_| "0.0.0.0:3001".to_string());
     let work_dir = resolve_work_dir(PathBuf::from(
         env::var("AGENT_WORK_DIR").unwrap_or_else(|_| "build".to_string()),
     ))?;

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 **/tmp/
 cloude-agentd
+vmlinux

--- a/backend/src/initramfs_manager.rs
+++ b/backend/src/initramfs_manager.rs
@@ -167,15 +167,30 @@ impl InitramfsLanguage {
     ) -> Result<bool, Error> {
         let out_mtime = fs::metadata(out_path)
             .and_then(|m| m.modified())
-            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to stat {}: {}", out_path.display(), e)))?;
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed to stat {}: {}", out_path.display(), e),
+                )
+            })?;
 
         let agent_mtime = fs::metadata(agent_binary)
             .and_then(|m| m.modified())
-            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to stat agent binary '{}': {}", agent_binary, e)))?;
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed to stat agent binary '{}': {}", agent_binary, e),
+                )
+            })?;
 
         let init_mtime = fs::metadata(init_script)
             .and_then(|m| m.modified())
-            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to stat init script '{}': {}", init_script, e)))?;
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed to stat init script '{}': {}", init_script, e),
+                )
+            })?;
 
         let image_mismatch = match Self::read_build_metadata(out_path) {
             Ok(Some(previous_base_image)) => previous_base_image != base_image,
@@ -183,7 +198,11 @@ impl InitramfsLanguage {
             Err(e) => {
                 return Err(Error::new(
                     ErrorKind::Other,
-                    format!("failed to read build metadata for {}: {}", out_path.display(), e),
+                    format!(
+                        "failed to read build metadata for {}: {}",
+                        out_path.display(),
+                        e
+                    ),
                 ));
             }
         };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -108,8 +108,7 @@ async fn main() -> Result<(), std::io::Error> {
         env::var("AGENT_BINARY_PATH").unwrap_or_else(|_| "./cloude-agentd".to_string());
 
     let init_script = env::var("INIT_SCRIPT_PATH").unwrap_or_else(|_| "./init.sh".to_string());
-    let vm_initramfs_dir =
-        env::var("VM_INITRAMFS_DIR").unwrap_or_else(|_| "./tmp".to_string());
+    let vm_initramfs_dir = env::var("VM_INITRAMFS_DIR").unwrap_or_else(|_| "./tmp".to_string());
 
     let available_languages: Vec<backend::initramfs_manager::InitramfsLanguage> =
         get_languages_config(&languages_config_path)?;
@@ -185,8 +184,7 @@ async fn main() -> Result<(), std::io::Error> {
         .build()
         .expect("Failed to build HTTP client");
 
-    let vm_kernel_path =
-        env::var("VM_KERNEL_PATH").unwrap_or_else(|_| "./vmlinux".to_string());
+    let vm_kernel_path = env::var("VM_KERNEL_PATH").unwrap_or_else(|_| "./vmlinux".to_string());
     let vm_log_guest_console = env::var("VM_LOG_GUEST_CONSOLE")
         .map(|v| {
             let normalized = v.trim().to_ascii_lowercase();
@@ -210,13 +208,19 @@ async fn main() -> Result<(), std::io::Error> {
     let host_space = 1_u32.checked_shl(host_bits).ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            format!("Failed to compute host address space from IP_MASK={}", ip_mask),
+            format!(
+                "Failed to compute host address space from IP_MASK={}",
+                ip_mask
+            ),
         )
     })?;
     let broadcast_offset = host_space.checked_sub(1).ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            format!("Failed to compute broadcast offset from IP_MASK={}", ip_mask),
+            format!(
+                "Failed to compute broadcast offset from IP_MASK={}",
+                ip_mask
+            ),
         )
     })?;
     let ip_range_u32 = u32::from(ip_range);

--- a/backend/src/vm_lifecycle.rs
+++ b/backend/src/vm_lifecycle.rs
@@ -238,19 +238,24 @@ impl VmHandle {
     }
 
     /// Build initramfs with embedded agent binary
-    async fn build_initramfs_with_agent(language: &str, config: &VmConfig) -> Result<PathBuf, VmError> {
+    async fn build_initramfs_with_agent(
+        language: &str,
+        config: &VmConfig,
+    ) -> Result<PathBuf, VmError> {
         debug!(language = %language, "Resolving language initramfs");
 
         let prefix = format!("{}-", language);
         let mut candidates: Vec<PathBuf> = Vec::new();
 
-        let mut entries = tokio::fs::read_dir(&config.initramfs_dir).await.map_err(|e| {
-            VmError::InitramfsBuild(format!(
-                "Failed to read initramfs dir '{}': {}",
-                config.initramfs_dir.display(),
-                e
-            ))
-        })?;
+        let mut entries = tokio::fs::read_dir(&config.initramfs_dir)
+            .await
+            .map_err(|e| {
+                VmError::InitramfsBuild(format!(
+                    "Failed to read initramfs dir '{}': {}",
+                    config.initramfs_dir.display(),
+                    e
+                ))
+            })?;
 
         while let Some(entry) = entries.next_entry().await.map_err(|e| {
             VmError::InitramfsBuild(format!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -118,13 +118,48 @@ async fn cmd_go(
     }
 
     let run: RunResponse = resp.json().await?;
-    println!("Job submitted successfully!");
-    println!("  ID: {}", run.id);
-    println!("\nCheck the result with:\n  cloude status {}", run.id);
-    Ok(())
+    let job_id = run.id.clone();
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let status_url = format!("{backend}/status/{job_id}");
+        let status_resp = client.get(&status_url).send().await?;
+
+        if !status_resp.status().is_success() {
+            let status = status_resp.status();
+            let err: ErrorBody = status_resp
+                .json()
+                .await
+                .unwrap_or(ErrorBody {
+                    error: format!("HTTP {status}"),
+                });
+            return Err(format!("Backend error (HTTP {status}): {}", err.error).into());
+        }
+
+        let st: StatusResponse = status_resp.json().await?;
+
+        if st.status == "done" || st.status == "error" {
+            println!("Status: {}", st.status);
+            if let Some(code) = st.exit_code {
+                println!("Exit code: {code}");
+            }
+            if let Some(ref out) = st.stdout {
+                if !out.is_empty() {
+                    println!("{out}");
+                }
+            }
+            if let Some(ref err) = st.stderr {
+                if !err.is_empty() {
+                    println!("{err}");
+                }
+            }
+            return Ok(());
+        }
+    }
 }
 
-// ── status: poll job result ─────────────────────────────────────────
+// ── status: query job result ────────────────────────────────────────
 
 async fn cmd_status(
     client: &reqwest::Client,
@@ -144,21 +179,10 @@ async fn cmd_status(
 
     let st: StatusResponse = resp.json().await?;
 
-    println!("Job {}", st.id);
-    println!("  Status: {}", st.status);
-
+    println!("Job ID: {}", st.id);
+    println!("Status: {}", st.status);
     if let Some(code) = st.exit_code {
-        println!("  Exit code: {code}");
-    }
-    if let Some(ref out) = st.stdout {
-        if !out.is_empty() {
-            println!("  ── stdout ──\n{out}");
-        }
-    }
-    if let Some(ref err) = st.stderr {
-        if !err.is_empty() {
-            println!("  ── stderr ──\n{err}");
-        }
+        println!("Exit code: {code}");
     }
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -128,12 +128,9 @@ async fn cmd_go(
 
         if !status_resp.status().is_success() {
             let status = status_resp.status();
-            let err: ErrorBody = status_resp
-                .json()
-                .await
-                .unwrap_or(ErrorBody {
-                    error: format!("HTTP {status}"),
-                });
+            let err: ErrorBody = status_resp.json().await.unwrap_or(ErrorBody {
+                error: format!("HTTP {status}"),
+            });
             return Err(format!("Backend error (HTTP {status}): {}", err.error).into());
         }
 

--- a/vmm/src/devices/stdin.rs
+++ b/vmm/src/devices/stdin.rs
@@ -52,7 +52,9 @@ impl MutEventSubscriber for StdinHandler {
                         }
                     }
                     Ok(0) => {
-                        if let Err(e) = ops.remove(Events::empty(&FdWrapper(self.input.as_raw_fd()))) {
+                        if let Err(e) =
+                            ops.remove(Events::empty(&FdWrapper(self.input.as_raw_fd())))
+                        {
                             eprintln!("Failed to remove stdin event on EOF: {:?}", e);
                         }
                     }
@@ -74,7 +76,10 @@ impl MutEventSubscriber for StdinHandler {
         if let Err(e) = ops.add(Events::with_data(&wrapper, STDIN_DATA, EventSet::IN)) {
             // This can legitimately fail with EPERM for non-epollable fds (e.g. /dev/null).
             // Stdin forwarding is optional for backend-driven jobs, so keep running.
-            eprintln!("Unable to add stdin event, disabling stdin forwarding: {:?}", e);
+            eprintln!(
+                "Unable to add stdin event, disabling stdin forwarding: {:?}",
+                e
+            );
         }
     }
 }


### PR DESCRIPTION
To test it, build and run backend following README. then run these commands : 

Run command with Python : `cargo run -p cli -- go --language python --file agent/examples/hello.py` 
Run command with NodeJS : `cargo run -p cli -- go --language node --file agent/examples/hello.js` 

For status command, type a run command, check the backend logs and copy the job ID. 
Then, type this command : `cargo run -p cli -- status <JOB_ID>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now polls for job completion and displays final status, optional exit code, and stdout/stderr.

* **Bug Fixes**
  * Status output simplified to show Job ID and status more clearly.
  * Backend job failures surface clearer HTTP/error details when available.

* **Chores**
  * Added vmlinux to backend ignore patterns.

* **Style**
  * Various message and formatting refinements across components for clearer logs and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->